### PR TITLE
Change file extension of image

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 
     <!-- Images -->
     <img
-      src="./images/snapmoji.jpg"
+      src="./images/snapmoji.png"
       alt="Snapmoji of Arsalan"
       width="100"
       height="100"


### PR DESCRIPTION
The file extension was coded as "jpg" instead of "png" which resulted in the image not being able to show on the page.